### PR TITLE
perf: fully stop WebGL loop off-screen, reduce observers, fix navbar …

### DIFF
--- a/app/components/experience-section.tsx
+++ b/app/components/experience-section.tsx
@@ -3,6 +3,18 @@ import React from "react";
 import { motion } from "framer-motion";
 import experiences from "@/app/data/experiences";
 
+const containerVariants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.08 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" } },
+};
+
 export default function ExperienceSection() {
   return (
     <section id="experience" className="py-32 lg:py-40 bg-subtle">
@@ -29,14 +41,17 @@ export default function ExperienceSection() {
           </h2>
         </motion.div>
 
-        <div className="space-y-0">
+        <motion.div
+          className="space-y-0"
+          variants={containerVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-50px" }}
+        >
           {experiences.map((exp, index) => (
             <motion.article
               key={index}
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, ease: "easeOut" }}
-              viewport={{ once: true }}
+              variants={itemVariants}
               className="grid lg:grid-cols-12 gap-8 py-12 border-t border-edge"
             >
               {/* Left: period + company */}
@@ -83,7 +98,7 @@ export default function ExperienceSection() {
               </div>
             </motion.article>
           ))}
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/app/components/expertise-section.tsx
+++ b/app/components/expertise-section.tsx
@@ -42,6 +42,18 @@ const areas = [
   },
 ];
 
+const containerVariants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.06 },
+  },
+};
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" } },
+};
+
 export default function ExpertiseSection() {
   return (
     <section id="expertise" className="py-32 lg:py-40">
@@ -76,14 +88,17 @@ export default function ExpertiseSection() {
           </p>
         </motion.div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-px bg-edge">
+        <motion.div
+          className="grid md:grid-cols-2 lg:grid-cols-3 gap-px bg-edge"
+          variants={containerVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-50px" }}
+        >
           {areas.map((area, index) => (
             <motion.div
               key={index}
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, ease: "easeOut", delay: index * 0.06 }}
-              viewport={{ once: true }}
+              variants={cardVariants}
               className="bg-base p-8 lg:p-10 group"
             >
               <Icon
@@ -107,7 +122,7 @@ export default function ExpertiseSection() {
               </p>
             </motion.div>
           ))}
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -25,7 +25,7 @@ const Navbar = memo(function Navbar() {
 
   return (
     <nav
-      className={`fixed w-full z-50 transition-colors duration-200 ease-out ${
+      className={`fixed w-full z-50 transition-colors duration-200 ease-out will-change-transform ${
         scrolled
           ? "bg-base/95 backdrop-blur-sm border-b border-edge"
           : "bg-transparent"

--- a/components/ui/tunnel-background.tsx
+++ b/components/ui/tunnel-background.tsx
@@ -162,23 +162,29 @@ export default function TunnelBackground() {
   const lastTimeRef = useRef<number>(0);
   const animRef = useRef<number | null>(null);
   const pausedRef = useRef<boolean>(false);
-  const offscreenRef = useRef<boolean>(false);
   const rafResizeRef = useRef<boolean>(false);
   const isMobile = useIsMobile();
 
-  const animate = useCallback((time: number) => {
-    if (!ctxRef.current) return;
-    if (pausedRef.current || offscreenRef.current) {
+  const startLoop = useCallback(() => {
+    if (animRef.current !== null) return;
+    const tick = (time: number) => {
+      if (!ctxRef.current) return;
+      time *= 0.001;
+      const delta = time - (lastTimeRef.current || time);
       lastTimeRef.current = time;
-      animRef.current = requestAnimationFrame(animate);
-      return;
+      ctxRef.current.material.uniforms.iTime.value += delta * 0.5;
+      ctxRef.current.renderer.render(ctxRef.current.scene, ctxRef.current.camera);
+      animRef.current = requestAnimationFrame(tick);
+    };
+    lastTimeRef.current = 0;
+    animRef.current = requestAnimationFrame(tick);
+  }, []);
+
+  const stopLoop = useCallback(() => {
+    if (animRef.current !== null) {
+      cancelAnimationFrame(animRef.current);
+      animRef.current = null;
     }
-    time *= 0.001;
-    const delta = time - (lastTimeRef.current || time);
-    lastTimeRef.current = time;
-    ctxRef.current.material.uniforms.iTime.value += delta * 0.5;
-    ctxRef.current.renderer.render(ctxRef.current.scene, ctxRef.current.camera);
-    animRef.current = requestAnimationFrame(animate);
   }, []);
 
   useEffect(() => {
@@ -191,10 +197,14 @@ export default function TunnelBackground() {
     const ctx = createThreeForCanvas(canvas, width, height, layers);
     ctxRef.current = ctx;
 
-    /* Pause rendering when the canvas scrolls out of viewport */
+    /* Fully stop/start the render loop based on viewport visibility */
     const observer = new IntersectionObserver(
       ([entry]) => {
-        offscreenRef.current = !entry.isIntersecting;
+        if (entry.isIntersecting && !pausedRef.current) {
+          startLoop();
+        } else {
+          stopLoop();
+        }
       },
       { threshold: 0 }
     );
@@ -220,15 +230,20 @@ export default function TunnelBackground() {
 
     const handleVisibility = () => {
       pausedRef.current = !!document.hidden;
+      if (document.hidden) {
+        stopLoop();
+      } else {
+        startLoop();
+      }
     };
     document.addEventListener("visibilitychange", handleVisibility);
     handleVisibility();
 
-    animRef.current = requestAnimationFrame(animate);
+    startLoop();
 
     return () => {
       observer.disconnect();
-      if (animRef.current) cancelAnimationFrame(animRef.current);
+      stopLoop();
       window.removeEventListener("resize", handleResize);
       document.removeEventListener("visibilitychange", handleVisibility);
       if (ctxRef.current) {
@@ -236,7 +251,7 @@ export default function TunnelBackground() {
         ctxRef.current = null;
       }
     };
-  }, [animate, isMobile]);
+  }, [startLoop, stopLoop, isMobile]);
 
   return (
     <canvas


### PR DESCRIPTION
…blur

Three remaining scroll performance issues:

1. The rAF loop was still scheduling frames when off-screen (just skipping the render call). Now fully stops/starts the loop via IntersectionObserver + visibility change.

2. The fixed navbar's backdrop-blur-sm was forcing the compositor to re-blur on every scroll frame. Added will-change-transform to promote it to its own layer.

3. ExperienceSection (7 items) and ExpertiseSection (6 cards) each had individual whileInView observers. Consolidated to one parent observer per section using Framer Motion staggerChildren variants. 13 IntersectionObservers → 2.

https://claude.ai/code/session_01SKLQWLfAyXFgcAPPDfYwWj