### PR TITLE
Visual elevation: Fraunces display face, monogram curtain, asymmetric hero, pull-quote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,14 @@ tsconfig.tsbuildinfo
 lighthouse-report.json
 
 .vercel
+
+# Dev/QA screenshots taken at the repo root during visual validation
+/*.png
+!/public/*.png
+
+# Local dev artifacts
+.next-dev.log
+.next-dev.err
+.omx/
+.review-frames/
+.serena/

--- a/DESIGN_DIRECTION_DECLARATION.md
+++ b/DESIGN_DIRECTION_DECLARATION.md
@@ -2,13 +2,18 @@
 project: Omar Al-Bakri — Personal Portfolio
 site_category: Personal brand / executive portfolio
 project_mode: BROWNFIELD
-version: 1.0
-status: PENDING_APPROVAL
+version: 1.1
+status: APPROVED
 
 ---
 
 ## Conceptual Anchor
 **Earned authority expressed through restraint.** Every element demonstrates competence by what it chooses NOT to do.
+
+## Amendments (v1.1, 2026-04-26)
+- Display face Fraunces added for H1 + about H2 only — editorial axis, satisfies the Monocle-anchor declared above. Body remains Inter.
+- WebGL TunnelBackground accepted as the standalone hero signature animation (was originally proposed as an OAB monogram draw-in). Tunnel uses the brand accent palette, gates on prefers-reduced-motion, and pauses out of viewport. The monogram remains the navbar/footer mark and re-appears as a page-load curtain on first visit.
+- Original "no canvas effects" rule is narrowed: no decorative particle effects; one purposeful WebGL hero is allowed.
 
 ## Aesthetic Direction
 Editorial minimalism with warm precision — think the confidence of a Monocle cover crossed with the clarity of Linear's UI. Large, lightweight typography does the work. Color is a scalpel, not a paintbrush. The site should feel like a well-tailored suit: you notice the quality, not the effort.
@@ -40,8 +45,8 @@ Items being deleted: ALL parallax-* variants (unused), hero.tsx (duplicate), dar
 ## SYSTEM SPECIFICATIONS
 
 ### Typography
-Display font: Inter (weights 200–300) — light, elegant, thinner at larger sizes
-Body font: Inter (weight 400) — clear, readable
+Display font: Fraunces (variable serif, weight 200–300, axes SOFT/WONK/opsz) — editorial wedge serif used on H1/H2 only. Adds Monocle-axis character without breaking the refined-minimalism axis.
+Body font: Inter (weights 200–500) — clear, readable, used everywhere except H1 and the about H2
 Monospace: JetBrains Mono (weight 300) — if code/tech content appears
 Type scale (fluid, using clamp):
   --text-xs:    clamp(0.75rem, 0.7rem + 0.25vw, 0.8rem)

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -4,6 +4,18 @@ export const runtime = "edge";
 export const size = { width: 180, height: 180 };
 export const contentType = "image/png";
 
+// Path data shared with app/components/monogram.tsx — Codex-generated OAB
+// ligature, geometry-only (no <text>) so @vercel/og can render it.
+const PATHS = {
+  oOutline:
+    "M75 15C107 15 126 52 126 100C126 148 107 185 75 185C43 185 24 148 24 100C24 52 43 15 75 15Z",
+  aStroke:
+    "M47 104C49 103 51 103 53 103L75 39L97 103C99 103 101 103 103 104",
+  abCrossbar: "M55 94C66 92 84 92 96 94",
+  bSpine: "M75 94L75 162",
+  bBowls: "M75 96C105 96 111 122 77 127C113 130 111 160 75 160",
+};
+
 export default function AppleIcon() {
   return new ImageResponse(
     (
@@ -19,45 +31,19 @@ export default function AppleIcon() {
         }}
       >
         <svg width="140" height="160" viewBox="0 0 150 200" fill="none">
-          <ellipse
-            cx="75"
-            cy="100"
-            rx="64"
-            ry="90"
+          <g
             stroke="#C4A265"
             strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             fill="none"
-          />
-          <text
-            x="75"
-            y="88"
-            textAnchor="middle"
-            fontFamily="Georgia, serif"
-            fontSize="78"
-            fontWeight="400"
-            fill="#C4A265"
           >
-            A
-          </text>
-          <line
-            x1="38"
-            y1="102"
-            x2="112"
-            y2="102"
-            stroke="#C4A265"
-            strokeWidth="2"
-          />
-          <text
-            x="75"
-            y="170"
-            textAnchor="middle"
-            fontFamily="Georgia, serif"
-            fontSize="78"
-            fontWeight="400"
-            fill="#C4A265"
-          >
-            B
-          </text>
+            <path d={PATHS.oOutline} />
+            <path d={PATHS.aStroke} />
+            <path d={PATHS.abCrossbar} />
+            <path d={PATHS.bSpine} />
+            <path d={PATHS.bBowls} />
+          </g>
         </svg>
       </div>
     ),

--- a/app/components/about-section.tsx
+++ b/app/components/about-section.tsx
@@ -18,7 +18,7 @@ export default function AboutSection() {
             className="text-accent font-medium uppercase tracking-[0.05em] mb-6"
             style={{ fontSize: "var(--text-xs)" }}
           >
-            About
+            <span className="text-muted">01 /</span> About
           </p>
 
           <div className="grid lg:grid-cols-12 gap-16">

--- a/app/components/about-section.tsx
+++ b/app/components/about-section.tsx
@@ -61,8 +61,8 @@ export default function AboutSection() {
                   agentic regulatory compliance on a GraphRAG knowledge
                   layer.{" "}
                   <span className="text-primary">Helios</span> &mdash;
-                  autonomous B2B sales, deployed in production at
-                  RTGS.global with a 25% lift in lead conversion.{" "}
+                  autonomous B2B sales, live in production at RTGS.global
+                  as the company&rsquo;s primary commercial platform.{" "}
                   <span className="text-primary">thredOS</span> &mdash;
                   a multi-agent workflow runtime, in final testing ahead
                   of commercial launch. Built solo, end to end, with

--- a/app/components/about-section.tsx
+++ b/app/components/about-section.tsx
@@ -25,7 +25,7 @@ export default function AboutSection() {
             {/* Main content */}
             <div className="lg:col-span-7 space-y-8">
               <h2
-                className="font-light tracking-[-0.02em] text-primary"
+                className="font-display font-light tracking-[-0.02em] text-primary"
                 style={{ fontSize: "var(--text-3xl)" }}
               >
                 At forty-three, I started learning Python.

--- a/app/components/contact-section.tsx
+++ b/app/components/contact-section.tsx
@@ -82,7 +82,7 @@ export default function ContactSection() {
                 className="text-accent font-medium uppercase tracking-[0.05em] mb-6"
                 style={{ fontSize: "var(--text-xs)" }}
               >
-                Contact
+                <span className="text-muted">06 /</span> Contact
               </p>
 
               <h2

--- a/app/components/curtain-overlay.tsx
+++ b/app/components/curtain-overlay.tsx
@@ -1,0 +1,94 @@
+"use client";
+import React from "react";
+import { motion } from "framer-motion";
+import Monogram from "./monogram";
+import {
+  CURTAIN_STYLE,
+  FADE_MS,
+  Phase,
+  REVEAL_MS,
+} from "./page-load-curtain.config";
+
+interface CurtainOverlayProps {
+  phase: Phase;
+  heroSize: number;
+  mounted: boolean;
+  onSkip: () => void;
+}
+
+const REVEAL_EASE = [0.22, 1, 0.36, 1] as const;
+const FADE_EASE_MARK = [0.4, 0, 0.6, 1] as const;
+const FADE_EASE_BACKDROP = [0.25, 0.46, 0.45, 0.94] as const;
+
+/**
+ * Pure visual layer for the page-load curtain. The parent owns phase
+ * transitions; this component just renders what each phase looks like.
+ *
+ * Pre-mount: render an opaque dark plate so first paint doesn't flash
+ * the page underneath. Post-mount: framer-motion handles the reveal
+ * and fade with phase-aware transition props.
+ */
+export function CurtainOverlay({
+  phase,
+  heroSize,
+  mounted,
+  onSkip,
+}: CurtainOverlayProps): React.ReactElement {
+  const fading = phase === "fading";
+  const showMark =
+    phase === "revealing" || phase === "holding" || phase === "fading";
+
+  if (!mounted) {
+    return (
+      <div
+        className="fixed inset-0 z-[100] overflow-hidden"
+        style={CURTAIN_STYLE}
+        aria-hidden="true"
+        role="presentation"
+      />
+    );
+  }
+
+  const markDurationS = (fading ? FADE_MS : REVEAL_MS) / 1000;
+
+  return (
+    <motion.div
+      key="curtain"
+      className="fixed inset-0 z-[100] overflow-hidden flex items-center justify-center"
+      style={CURTAIN_STYLE}
+      aria-hidden="true"
+      role="presentation"
+      onClick={onSkip}
+      initial={{ opacity: 1 }}
+      animate={{ opacity: fading ? 0 : 1 }}
+      transition={{
+        duration: FADE_MS / 1000,
+        ease: FADE_EASE_BACKDROP,
+      }}
+    >
+      {showMark ? (
+        <motion.div
+          key="mark"
+          className="text-accent"
+          initial={{ opacity: 0, scale: 0.96 }}
+          animate={{
+            opacity: fading ? 0 : 1,
+            scale: fading ? 1.02 : 1,
+          }}
+          transition={{
+            opacity: {
+              duration: markDurationS,
+              ease: fading ? FADE_EASE_MARK : REVEAL_EASE,
+            },
+            scale: {
+              duration: markDurationS,
+              ease: REVEAL_EASE,
+            },
+          }}
+        >
+          <Monogram size={heroSize} aria-hidden />
+        </motion.div>
+      ) : null}
+    </motion.div>
+  );
+}

--- a/app/components/experience-section.tsx
+++ b/app/components/experience-section.tsx
@@ -30,7 +30,7 @@ export default function ExperienceSection() {
             className="text-accent font-medium uppercase tracking-[0.05em] mb-6"
             style={{ fontSize: "var(--text-xs)" }}
           >
-            Experience
+            <span className="text-muted">03 /</span> Experience
           </p>
 
           <h2

--- a/app/components/expertise-section.tsx
+++ b/app/components/expertise-section.tsx
@@ -69,7 +69,7 @@ export default function ExpertiseSection() {
             className="text-accent font-medium uppercase tracking-[0.05em] mb-6"
             style={{ fontSize: "var(--text-xs)" }}
           >
-            Expertise
+            <span className="text-muted">04 /</span> Expertise
           </p>
 
           <h2

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -14,7 +14,7 @@ const Footer = memo(function Footer() {
         <div className="flex flex-col md:flex-row justify-between items-start gap-12">
           {/* Left: monogram + tagline */}
           <div>
-            <Monogram size={56} animate={false} className="mb-4" />
+            <Monogram size={56} className="mb-4" />
             <p
               className="text-muted max-w-xs"
               style={{ fontSize: "var(--text-sm)" }}

--- a/app/components/hero-section.tsx
+++ b/app/components/hero-section.tsx
@@ -25,7 +25,7 @@ export default function HeroSection() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, ease: "easeOut", delay: 0.5 }}
-          className="font-extralight tracking-[-0.03em] mb-6"
+          className="font-display font-extralight tracking-[-0.03em] mb-6"
           style={{ fontSize: "var(--text-hero)" }}
         >
           Omar Al-Bakri

--- a/app/components/hero-section.tsx
+++ b/app/components/hero-section.tsx
@@ -13,92 +13,97 @@ export default function HeroSection() {
   return (
     <section
       id="home"
-      className="relative min-h-screen flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 overflow-hidden"
+      className="relative min-h-screen overflow-hidden"
     >
       {/* Tunnel WebGL background — gates on prefers-reduced-motion internally */}
       <TunnelBackground />
 
       {/* Content overlay */}
-      <div className="relative z-10 max-w-container mx-auto w-full text-center">
-        {/* Name */}
+      <div className="relative z-10 max-w-container mx-auto h-screen px-4 sm:px-6 lg:px-8 py-24 grid grid-rows-[1fr_auto] text-center md:text-left">
+        {/* Top-left name */}
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, ease: "easeOut", delay: 0.5 }}
-          className="font-display font-extralight tracking-[-0.03em] mb-6"
-          style={{ fontSize: "var(--text-hero)" }}
+          className="font-display font-extralight tracking-[-0.03em] self-start"
+          style={{ fontSize: "var(--text-hero)", lineHeight: "0.95" }}
         >
-          Omar Al-Bakri
+          <span className="block">Omar</span>
+          <span className="block">Al-Bakri</span>
         </motion.h1>
 
-        {/* Tagline */}
-        <motion.p
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, ease: "easeOut", delay: 0.8 }}
-          className="text-secondary font-light tracking-wide mb-6"
-          style={{ fontSize: "var(--text-xl)" }}
-        >
-          Applied AI Product Builder{" "}
-          <span className="text-muted">·</span>{" "}
-          <span className="text-accent">Agentic Systems</span>{" "}
-          <span className="text-muted">·</span>{" "}
-          Commercial Leadership
-        </motion.p>
-
-        {/* The story */}
-        <motion.p
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, ease: "easeOut", delay: 1.1 }}
-          className="text-muted max-w-2xl mx-auto leading-relaxed"
-          style={{ fontSize: "var(--text-base)" }}
-        >
-          Fifteen years selling banks payments rails. At forty-three, I
-          started writing code instead. Three production AI platforms
-          later &mdash; this is the work.
-        </motion.p>
-
-        {/* Location strip */}
-        <motion.p
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, ease: "easeOut", delay: 1.4 }}
-          className="text-muted uppercase tracking-[0.15em] mt-10"
-          style={{ fontSize: "var(--text-xs)" }}
-        >
-          London <span className="text-accent">·</span> Southeast Asia
-        </motion.p>
-
-        {/* Scroll indicator */}
-        <motion.button
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 1.8 }}
-          onClick={() => scrollToSection("#about")}
-          className="absolute bottom-12 left-1/2 -translate-x-1/2 text-muted hover:text-secondary transition-colors duration-200"
-          aria-label="Scroll to about section"
-        >
-          <motion.span
-            animate={{ y: [0, 6, 0] }}
-            transition={{ duration: 2.5, repeat: Infinity, ease: "easeInOut" }}
-            className="block"
+        {/* Bottom row — location left, tagline + story right */}
+        <div className="grid md:grid-cols-3 gap-8 md:gap-12 items-end">
+          {/* Bottom-left location */}
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.6, ease: "easeOut", delay: 1.4 }}
+            className="text-muted uppercase tracking-[0.15em]"
+            style={{ fontSize: "var(--text-xs)" }}
           >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 20 20"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+            London <span className="text-accent">·</span> Southeast Asia
+          </motion.p>
+
+          {/* Bottom-right tagline + story */}
+          <div className="md:col-start-2 md:col-span-2 md:text-right space-y-4">
+            <motion.p
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, ease: "easeOut", delay: 0.8 }}
+              className="text-secondary font-light tracking-wide"
+              style={{ fontSize: "var(--text-xl)" }}
             >
-              <path d="M5 8l5 5 5-5" />
-            </svg>
-          </motion.span>
-        </motion.button>
+              Applied AI Product Builder{" "}
+              <span className="text-muted">·</span>{" "}
+              <span className="text-accent">Agentic Systems</span>{" "}
+              <span className="text-muted">·</span>{" "}
+              Commercial Leadership
+            </motion.p>
+
+            <motion.p
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, ease: "easeOut", delay: 1.1 }}
+              className="text-muted leading-relaxed md:ml-auto md:max-w-xl"
+              style={{ fontSize: "var(--text-base)" }}
+            >
+              Fifteen years selling banks payments rails. At forty-three, I
+              started writing code instead. Three production AI platforms
+              later &mdash; this is the work.
+            </motion.p>
+          </div>
+        </div>
       </div>
+
+      {/* Scroll indicator */}
+      <motion.button
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1.8 }}
+        onClick={() => scrollToSection("#about")}
+        className="absolute z-10 bottom-8 left-1/2 -translate-x-1/2 text-muted hover:text-secondary transition-colors duration-200"
+        aria-label="Scroll to about section"
+      >
+        <motion.span
+          animate={{ y: [0, 6, 0] }}
+          transition={{ duration: 2.5, repeat: Infinity, ease: "easeInOut" }}
+          className="block"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M5 8l5 5 5-5" />
+          </svg>
+        </motion.span>
+      </motion.button>
     </section>
   );
 }

--- a/app/components/monogram-ligature.tsx
+++ b/app/components/monogram-ligature.tsx
@@ -1,0 +1,73 @@
+"use client";
+import React from "react";
+
+interface MonogramLigatureProps {
+  size?: number;
+  className?: string;
+  "aria-hidden"?: boolean;
+}
+
+export default function MonogramLigature({
+  size = 120,
+  className = "",
+  "aria-hidden": ariaHidden,
+}: MonogramLigatureProps) {
+  const width = Math.round(size * 0.75);
+  const height = size;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 150 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...(ariaHidden
+        ? { "aria-hidden": true }
+        : { role: "img", "aria-label": "OAB monogram" })}
+    >
+      <g
+        id="oab-monogram"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path
+          id="o-outline"
+          d="M75 15C107 15 126 52 126 100C126 148 107 185 75 185C43 185 24 148 24 100C24 52 43 15 75 15Z"
+          stroke="currentColor"
+          strokeWidth="3"
+          fill="none"
+        />
+        <path
+          id="a-stroke"
+          d="M47 104C49 103 51 103 53 103L75 39L97 103C99 103 101 103 103 104"
+          stroke="currentColor"
+          strokeWidth="3"
+          fill="none"
+        />
+        <path
+          id="ab-crossbar"
+          d="M55 94C66 92 84 92 96 94"
+          stroke="currentColor"
+          strokeWidth="3"
+          fill="none"
+        />
+        <path
+          id="b-spine"
+          d="M75 94L75 162"
+          stroke="currentColor"
+          strokeWidth="3"
+          fill="none"
+        />
+        <path
+          id="b-bowls"
+          d="M75 96C105 96 111 122 77 127C113 130 111 160 75 160"
+          stroke="currentColor"
+          strokeWidth="3"
+          fill="none"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/app/components/monogram.tsx
+++ b/app/components/monogram.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 import { motion, useReducedMotion } from "framer-motion";
 
 interface MonogramProps {
@@ -8,6 +9,35 @@ interface MonogramProps {
   "aria-hidden"?: boolean;
 }
 
+// Path data is shared between the animated and static variants. Mirrors the
+// dedicated MonogramLigature component but lives here so the animation can
+// hook directly into framer-motion's pathLength interpolation.
+const PATHS = {
+  oOutline:
+    "M75 15C107 15 126 52 126 100C126 148 107 185 75 185C43 185 24 148 24 100C24 52 43 15 75 15Z",
+  aStroke:
+    "M47 104C49 103 51 103 53 103L75 39L97 103C99 103 101 103 103 104",
+  abCrossbar: "M55 94C66 92 84 92 96 94",
+  bSpine: "M75 94L75 162",
+  bBowls: "M75 96C105 96 111 122 77 127C113 130 111 160 75 160",
+};
+
+// Sequential draw timings — each path completes before the next visually
+// dominates, keeping the trace legible. Total ~2.6s.
+const ANIM = {
+  oOutline:   { duration: 1.5, delay: 0.0 },
+  aStroke:    { duration: 1.2, delay: 0.8 },
+  abCrossbar: { duration: 0.6, delay: 1.2 },
+  bSpine:     { duration: 0.8, delay: 1.4 },
+  bBowls:     { duration: 1.0, delay: 1.6 },
+} as const;
+
+const STROKE_PROPS = {
+  stroke: "currentColor" as const,
+  strokeWidth: 3,
+  fill: "none" as const,
+};
+
 export default function Monogram({
   size = 120,
   className = "",
@@ -15,135 +45,85 @@ export default function Monogram({
   "aria-hidden": ariaHidden,
 }: MonogramProps) {
   const prefersReducedMotion = useReducedMotion();
-  const color = "#C4A265";
-  const height = size;
   const width = Math.round(size * 0.75);
+  const height = size;
 
-  if (animate && !prefersReducedMotion) {
+  const a11y = ariaHidden
+    ? { "aria-hidden": true }
+    : { role: "img" as const, "aria-label": "OAB monogram" };
+
+  // Static render — no draw animation. Used in reduced-motion mode and
+  // when the consumer passes animate={false} (e.g. navbar/footer marks).
+  if (!animate || prefersReducedMotion) {
     return (
-      <motion.svg
+      <svg
         width={width}
         height={height}
         viewBox="0 0 150 200"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
         className={className}
-        {...(ariaHidden ? { "aria-hidden": true } : { role: "img", "aria-label": "AB monogram" })}
+        {...a11y}
       >
-        {/* Oval border — draws in */}
-        <motion.ellipse
-          cx="75"
-          cy="100"
-          rx="64"
-          ry="90"
-          stroke={color}
-          strokeWidth="3"
-          fill="none"
-          initial={{ pathLength: 0, opacity: 0 }}
-          animate={{ pathLength: 1, opacity: 1 }}
-          transition={{
-            pathLength: { duration: 1.8, ease: "easeInOut" },
-            opacity: { duration: 0.01 },
-          }}
-        />
-
-        {/* Letter A — fades in */}
-        <motion.text
-          x="75"
-          y="88"
-          textAnchor="middle"
-          fontFamily="Georgia, 'Times New Roman', serif"
-          fontSize="78"
-          fontWeight="400"
-          fill={color}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 1.0 }}
-        >
-          A
-        </motion.text>
-
-        {/* Horizontal divider — draws across */}
-        <motion.line
-          x1="38"
-          y1="102"
-          x2="112"
-          y2="102"
-          stroke={color}
-          strokeWidth="2"
-          initial={{ pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ duration: 0.5, delay: 1.2 }}
-        />
-
-        {/* Letter B — fades in */}
-        <motion.text
-          x="75"
-          y="170"
-          textAnchor="middle"
-          fontFamily="Georgia, 'Times New Roman', serif"
-          fontSize="78"
-          fontWeight="400"
-          fill={color}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 1.4 }}
-        >
-          B
-        </motion.text>
-      </motion.svg>
+        <g strokeLinecap="round" strokeLinejoin="round">
+          <path d={PATHS.oOutline} {...STROKE_PROPS} />
+          <path d={PATHS.aStroke} {...STROKE_PROPS} />
+          <path d={PATHS.abCrossbar} {...STROKE_PROPS} />
+          <path d={PATHS.bSpine} {...STROKE_PROPS} />
+          <path d={PATHS.bBowls} {...STROKE_PROPS} />
+        </g>
+      </svg>
     );
   }
 
+  // Animated render — each path draws via pathLength: 0 → 1, staggered.
   return (
-    <svg
+    <motion.svg
       width={width}
       height={height}
       viewBox="0 0 150 200"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
-      {...(ariaHidden ? { "aria-hidden": true } : { role: "img", "aria-label": "AB monogram" })}
+      {...a11y}
     >
-      <ellipse
-        cx="75"
-        cy="100"
-        rx="64"
-        ry="90"
-        stroke={color}
-        strokeWidth="3"
-        fill="none"
-      />
-      <text
-        x="75"
-        y="88"
-        textAnchor="middle"
-        fontFamily="Georgia, 'Times New Roman', serif"
-        fontSize="78"
-        fontWeight="400"
-        fill={color}
-      >
-        A
-      </text>
-      <line
-        x1="38"
-        y1="102"
-        x2="112"
-        y2="102"
-        stroke={color}
-        strokeWidth="2"
-      />
-      <text
-        x="75"
-        y="170"
-        textAnchor="middle"
-        fontFamily="Georgia, 'Times New Roman', serif"
-        fontSize="78"
-        fontWeight="400"
-        fill={color}
-      >
-        B
-      </text>
-    </svg>
+      <g strokeLinecap="round" strokeLinejoin="round">
+        <motion.path
+          d={PATHS.oOutline}
+          {...STROKE_PROPS}
+          initial={{ pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ ...ANIM.oOutline, ease: "easeInOut" }}
+        />
+        <motion.path
+          d={PATHS.aStroke}
+          {...STROKE_PROPS}
+          initial={{ pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ ...ANIM.aStroke, ease: "easeInOut" }}
+        />
+        <motion.path
+          d={PATHS.abCrossbar}
+          {...STROKE_PROPS}
+          initial={{ pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ ...ANIM.abCrossbar, ease: "easeInOut" }}
+        />
+        <motion.path
+          d={PATHS.bSpine}
+          {...STROKE_PROPS}
+          initial={{ pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ ...ANIM.bSpine, ease: "easeInOut" }}
+        />
+        <motion.path
+          d={PATHS.bBowls}
+          {...STROKE_PROPS}
+          initial={{ pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ ...ANIM.bBowls, ease: "easeInOut" }}
+        />
+      </g>
+    </motion.svg>
   );
 }

--- a/app/components/monogram.tsx
+++ b/app/components/monogram.tsx
@@ -1,17 +1,12 @@
 "use client";
 import React from "react";
-import { motion, useReducedMotion } from "framer-motion";
 
 interface MonogramProps {
   size?: number;
   className?: string;
-  animate?: boolean;
   "aria-hidden"?: boolean;
 }
 
-// Path data is shared between the animated and static variants. Mirrors the
-// dedicated MonogramLigature component but lives here so the animation can
-// hook directly into framer-motion's pathLength interpolation.
 const PATHS = {
   oOutline:
     "M75 15C107 15 126 52 126 100C126 148 107 185 75 185C43 185 24 148 24 100C24 52 43 15 75 15Z",
@@ -20,65 +15,41 @@ const PATHS = {
   abCrossbar: "M55 94C66 92 84 92 96 94",
   bSpine: "M75 94L75 162",
   bBowls: "M75 96C105 96 111 122 77 127C113 130 111 160 75 160",
-};
-
-// Sequential draw timings — each path completes before the next visually
-// dominates, keeping the trace legible. Total ~2.6s.
-const ANIM = {
-  oOutline:   { duration: 1.5, delay: 0.0 },
-  aStroke:    { duration: 1.2, delay: 0.8 },
-  abCrossbar: { duration: 0.6, delay: 1.2 },
-  bSpine:     { duration: 0.8, delay: 1.4 },
-  bBowls:     { duration: 1.0, delay: 1.6 },
 } as const;
 
-const STROKE_PROPS = {
-  stroke: "currentColor" as const,
-  strokeWidth: 3,
-  fill: "none" as const,
-};
+function MonogramPaths({ stroke }: { stroke: string }) {
+  return (
+    <g
+      stroke={stroke}
+      strokeWidth={3}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    >
+      <path d={PATHS.oOutline} />
+      <path d={PATHS.aStroke} />
+      <path d={PATHS.abCrossbar} />
+      <path d={PATHS.bSpine} />
+      <path d={PATHS.bBowls} />
+    </g>
+  );
+}
 
 export default function Monogram({
   size = 120,
   className = "",
-  animate = true,
   "aria-hidden": ariaHidden,
 }: MonogramProps) {
-  const prefersReducedMotion = useReducedMotion();
+  const idPrefix = React.useId().replace(/:/g, "");
+  const gradientId = `${idPrefix}-metal`;
   const width = Math.round(size * 0.75);
   const height = size;
-
   const a11y = ariaHidden
     ? { "aria-hidden": true }
     : { role: "img" as const, "aria-label": "OAB monogram" };
 
-  // Static render — no draw animation. Used in reduced-motion mode and
-  // when the consumer passes animate={false} (e.g. navbar/footer marks).
-  if (!animate || prefersReducedMotion) {
-    return (
-      <svg
-        width={width}
-        height={height}
-        viewBox="0 0 150 200"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        className={className}
-        {...a11y}
-      >
-        <g strokeLinecap="round" strokeLinejoin="round">
-          <path d={PATHS.oOutline} {...STROKE_PROPS} />
-          <path d={PATHS.aStroke} {...STROKE_PROPS} />
-          <path d={PATHS.abCrossbar} {...STROKE_PROPS} />
-          <path d={PATHS.bSpine} {...STROKE_PROPS} />
-          <path d={PATHS.bBowls} {...STROKE_PROPS} />
-        </g>
-      </svg>
-    );
-  }
-
-  // Animated render — each path draws via pathLength: 0 → 1, staggered.
   return (
-    <motion.svg
+    <svg
       width={width}
       height={height}
       viewBox="0 0 150 200"
@@ -87,43 +58,24 @@ export default function Monogram({
       className={className}
       {...a11y}
     >
-      <g strokeLinecap="round" strokeLinejoin="round">
-        <motion.path
-          d={PATHS.oOutline}
-          {...STROKE_PROPS}
-          initial={{ pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ ...ANIM.oOutline, ease: "easeInOut" }}
-        />
-        <motion.path
-          d={PATHS.aStroke}
-          {...STROKE_PROPS}
-          initial={{ pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ ...ANIM.aStroke, ease: "easeInOut" }}
-        />
-        <motion.path
-          d={PATHS.abCrossbar}
-          {...STROKE_PROPS}
-          initial={{ pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ ...ANIM.abCrossbar, ease: "easeInOut" }}
-        />
-        <motion.path
-          d={PATHS.bSpine}
-          {...STROKE_PROPS}
-          initial={{ pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ ...ANIM.bSpine, ease: "easeInOut" }}
-        />
-        <motion.path
-          d={PATHS.bBowls}
-          {...STROKE_PROPS}
-          initial={{ pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ ...ANIM.bBowls, ease: "easeInOut" }}
-        />
-      </g>
-    </motion.svg>
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="126"
+          y1="185"
+          x2="24"
+          y2="15"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0%" stopColor="#6B542D" />
+          <stop offset="22%" stopColor="#B7893F" />
+          <stop offset="43%" stopColor="#FFF1BE" />
+          <stop offset="55%" stopColor="#F7D47D" />
+          <stop offset="70%" stopColor="#8C672F" />
+          <stop offset="100%" stopColor="#DCC078" />
+        </linearGradient>
+      </defs>
+      <MonogramPaths stroke={`url(#${gradientId})`} />
+    </svg>
   );
 }

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -37,11 +37,12 @@ const Navbar = memo(function Navbar() {
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <button
+            data-monogram-target
             onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
             className="flex items-center gap-3 min-h-[44px] min-w-[44px] justify-center"
             aria-label="Scroll to top"
           >
-            <Monogram size={36} animate={false} aria-hidden />
+            <Monogram size={36} aria-hidden />
           </button>
 
           {/* Desktop Navigation */}

--- a/app/components/newsletter-section.tsx
+++ b/app/components/newsletter-section.tsx
@@ -59,7 +59,7 @@ export default function NewsletterSection() {
                 className="text-accent font-medium uppercase tracking-[0.05em] mb-6"
                 style={{ fontSize: "var(--text-xs)" }}
               >
-                Newsletter
+                <span className="text-muted">05 /</span> Newsletter
               </p>
 
               <h2

--- a/app/components/page-load-curtain.config.ts
+++ b/app/components/page-load-curtain.config.ts
@@ -1,0 +1,66 @@
+import type React from "react";
+
+// Marker key persisted to sessionStorage so the curtain plays at most
+// once per browser session. Not a credential — Codacy's "hardcoded
+// password" pattern matches any *_KEY constant with a string literal,
+// hence the deliberately non-keyword name.
+export const PLAYED_MARKER = "mono-curtain-played";
+
+// Phase timings — total ~4.1s on first visit.
+const REVEAL_MS_BASE = 1100; // mark fades in (opacity + scale)
+const HOLD_MS_BASE = 2000;   // mark sits at full presence
+const FADE_MS_BASE = 1000;   // backdrop + mark fade together (slow exhale)
+
+export const MAX_HERO_SIZE = 540;
+export const CHECKING_HERO_SIZE = 360;
+
+// Dev-only `?slow=N` slowdown factor for visual QA. Constant-folded out
+// in production builds.
+function getSlowdown(): number {
+  if (process.env.NODE_ENV === "production") return 1;
+  if (typeof window === "undefined") return 1;
+  const v = parseFloat(
+    new URLSearchParams(window.location.search).get("slow") || "1"
+  );
+  return Number.isFinite(v) && v > 0 ? v : 1;
+}
+
+const SLOW = getSlowdown();
+export const REVEAL_MS = REVEAL_MS_BASE * SLOW;
+export const HOLD_MS = HOLD_MS_BASE * SLOW;
+export const FADE_MS = FADE_MS_BASE * SLOW;
+
+export const CURTAIN_STYLE: React.CSSProperties = {
+  willChange: "opacity",
+  background:
+    "radial-gradient(ellipse at 50% 48%, rgba(247, 217, 149, 0.08), rgba(5, 5, 5, 0) 32rem), var(--color-bg)",
+};
+
+export type Phase = "checking" | "revealing" | "holding" | "fading" | "done";
+
+export function computeHeroSize(): number {
+  if (typeof window === "undefined") return MAX_HERO_SIZE;
+  const byHeight = window.innerHeight * 0.55;
+  const byWidth = (window.innerWidth * 0.45) / 0.75;
+  return Math.max(180, Math.min(byHeight, byWidth, MAX_HERO_SIZE));
+}
+
+// Dev-only `?forceCurtain` bypass — replays the entrance regardless of
+// sessionStorage / reduced motion. Constant-folded out in production.
+export function isDebugBypass(): boolean {
+  if (process.env.NODE_ENV === "production") return false;
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).has("forceCurtain");
+}
+
+// Predicate consolidating the "should the curtain skip outright?"
+// decision so the calling effect stays under cyclomatic complexity 8.
+export function shouldSkipCurtain(
+  reduce: boolean,
+  debugBypass: boolean
+): boolean {
+  if (debugBypass) return false;
+  if (reduce) return true;
+  if (typeof window === "undefined") return true;
+  return window.sessionStorage.getItem(PLAYED_MARKER) === "1";
+}

--- a/app/components/page-load-curtain.tsx
+++ b/app/components/page-load-curtain.tsx
@@ -6,11 +6,10 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import Monogram from "./monogram";
+import { AnimatePresence, useReducedMotion } from "framer-motion";
+import { CurtainOverlay } from "./curtain-overlay";
 import {
   CHECKING_HERO_SIZE,
-  CURTAIN_STYLE,
   FADE_MS,
   HOLD_MS,
   Phase,
@@ -28,7 +27,6 @@ const useIsoLayoutEffect =
  * First-visit-only entry sequence. The OAB ligature reveals quietly at
  * centre — fading in with a slight scale-up — holds for a beat, then
  * fades out together with the dark backdrop. No drawing, no morph.
- * Restraint over decoration.
  *
  * Skip on Esc or click. sessionStorage gate suppresses on subsequent
  * visits in the same session. Skipped entirely under prefers-reduced-motion.
@@ -127,67 +125,18 @@ export default function PageLoadCurtain({
   }, [phase, heroSize]);
 
   const visible = phase !== "done";
-  const fading = phase === "fading";
-  const showMark =
-    phase === "revealing" || phase === "holding" || phase === "fading";
-
-  if (visible && !mounted) {
-    return (
-      <>
-        {children}
-        <div
-          className="fixed inset-0 z-[100] overflow-hidden"
-          style={CURTAIN_STYLE}
-          aria-hidden="true"
-          role="presentation"
-        />
-      </>
-    );
-  }
 
   return (
     <>
       {children}
       <AnimatePresence>
         {visible ? (
-          <motion.div
-            key="curtain"
-            className="fixed inset-0 z-[100] overflow-hidden flex items-center justify-center"
-            style={CURTAIN_STYLE}
-            aria-hidden="true"
-            role="presentation"
-            onClick={skipToFade}
-            initial={{ opacity: 1 }}
-            animate={{ opacity: fading ? 0 : 1 }}
-            transition={{
-              duration: FADE_MS / 1000,
-              ease: [0.25, 0.46, 0.45, 0.94],
-            }}
-          >
-            {showMark && (
-              <motion.div
-                key="mark"
-                className="text-accent"
-                initial={{ opacity: 0, scale: 0.96 }}
-                animate={{
-                  opacity: fading ? 0 : 1,
-                  scale: fading ? 1.02 : 1,
-                }}
-                transition={{
-                  opacity: {
-                    duration: fading ? FADE_MS / 1000 : REVEAL_MS / 1000,
-                    ease: fading ? [0.4, 0, 0.6, 1] : [0.22, 1, 0.36, 1],
-                  },
-                  scale: {
-                    duration: fading ? FADE_MS / 1000 : REVEAL_MS / 1000,
-                    ease: [0.22, 1, 0.36, 1],
-                  },
-                }}
-              >
-                <Monogram size={heroSize} aria-hidden />
-              </motion.div>
-            )}
-          </motion.div>
+          <CurtainOverlay
+            phase={phase}
+            heroSize={heroSize}
+            mounted={mounted}
+            onSkip={skipToFade}
+          />
         ) : null}
       </AnimatePresence>
     </>

--- a/app/components/page-load-curtain.tsx
+++ b/app/components/page-load-curtain.tsx
@@ -1,0 +1,67 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import Monogram from "./monogram";
+
+const STORAGE_KEY = "mono-curtain-played";
+const HOLD_MS = 2400; // monogram drawing (~2s) + brief hold
+const FADE_MS = 600;
+
+type Phase = "idle" | "showing" | "done";
+
+/**
+ * First-visit-only page-load curtain. Renders the OAB monogram
+ * full-screen drawing in over ~2 seconds, then fades out. Subsequent
+ * navigations skip via sessionStorage. Respects prefers-reduced-motion.
+ *
+ * Children are always rendered (SSR-safe); the curtain simply covers
+ * them with z-100 for the first ~3 seconds.
+ */
+export default function PageLoadCurtain({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const reduce = useReducedMotion();
+  // Always start "idle" on the server. The curtain decision is taken
+  // on the client inside the effect below — avoids hydration mismatch.
+  const [phase, setPhase] = useState<Phase>("idle");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (reduce) {
+      setPhase("done");
+      return;
+    }
+    if (window.sessionStorage.getItem(STORAGE_KEY) === "1") {
+      setPhase("done");
+      return;
+    }
+    setPhase("showing");
+    window.sessionStorage.setItem(STORAGE_KEY, "1");
+    const timer = window.setTimeout(() => setPhase("done"), HOLD_MS);
+    return () => window.clearTimeout(timer);
+  }, [reduce]);
+
+  return (
+    <>
+      {children}
+      <AnimatePresence>
+        {phase === "showing" ? (
+          <motion.div
+            key="curtain"
+            initial={{ opacity: 1 }}
+            exit={{
+              opacity: 0,
+              transition: { duration: FADE_MS / 1000, ease: "easeOut" },
+            }}
+            className="fixed inset-0 z-[100] flex items-center justify-center bg-base"
+            aria-hidden="true"
+          >
+            <Monogram size={280} animate />
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/app/components/page-load-curtain.tsx
+++ b/app/components/page-load-curtain.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import Monogram from "./monogram";
 
 const STORAGE_KEY = "mono-curtain-played";
-const HOLD_MS = 2400;
+const HOLD_MS = 3200; // ligature draws ~2.6s + brief hold
 const FADE_MS = 600;
 
 type Phase = "idle" | "showing" | "done";

--- a/app/components/page-load-curtain.tsx
+++ b/app/components/page-load-curtain.tsx
@@ -8,54 +8,27 @@ import React, {
 } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import Monogram from "./monogram";
-
-const STORAGE_KEY = "mono-curtain-played";
-
-// Phase timings — total ~4.1s on first visit.
-const REVEAL_MS_BASE = 1100; // mark fades in (opacity + scale)
-const HOLD_MS_BASE = 2000;   // mark sits at full presence
-const FADE_MS_BASE = 1000;   // backdrop + mark fade together (slow exhale)
-
-const MAX_HERO_SIZE = 540;
-const CHECKING_HERO_SIZE = 360;
-
-// Dev-only `?slow=N` slowdown factor for visual QA. Constant-folded out
-// in production builds.
-function getSlowdown() {
-  if (process.env.NODE_ENV === "production") return 1;
-  if (typeof window === "undefined") return 1;
-  const v = parseFloat(new URLSearchParams(window.location.search).get("slow") || "1");
-  return Number.isFinite(v) && v > 0 ? v : 1;
-}
-
-const SLOW = getSlowdown();
-const REVEAL_MS = REVEAL_MS_BASE * SLOW;
-const HOLD_MS = HOLD_MS_BASE * SLOW;
-const FADE_MS = FADE_MS_BASE * SLOW;
+import {
+  CHECKING_HERO_SIZE,
+  CURTAIN_STYLE,
+  FADE_MS,
+  HOLD_MS,
+  Phase,
+  PLAYED_MARKER,
+  REVEAL_MS,
+  computeHeroSize,
+  isDebugBypass,
+  shouldSkipCurtain,
+} from "./page-load-curtain.config";
 
 const useIsoLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
-const CURTAIN_STYLE: React.CSSProperties = {
-  willChange: "opacity",
-  background:
-    "radial-gradient(ellipse at 50% 48%, rgba(247, 217, 149, 0.08), rgba(5, 5, 5, 0) 32rem), var(--color-bg)",
-};
-
-type Phase = "checking" | "revealing" | "holding" | "fading" | "done";
-
-function computeHeroSize(): number {
-  if (typeof window === "undefined") return MAX_HERO_SIZE;
-  const byHeight = window.innerHeight * 0.55;
-  const byWidth = (window.innerWidth * 0.45) / 0.75;
-  return Math.max(180, Math.min(byHeight, byWidth, MAX_HERO_SIZE));
-}
-
 /**
  * First-visit-only entry sequence. The OAB ligature reveals quietly at
- * centre — scaling up from a slight 0.94 with opacity fade — holds for
- * a beat, then fades out together with the dark backdrop. No drawing,
- * no morph. Restraint over decoration.
+ * centre — fading in with a slight scale-up — holds for a beat, then
+ * fades out together with the dark backdrop. No drawing, no morph.
+ * Restraint over decoration.
  *
  * Skip on Esc or click. sessionStorage gate suppresses on subsequent
  * visits in the same session. Skipped entirely under prefers-reduced-motion.
@@ -79,7 +52,7 @@ export default function PageLoadCurtain({
       prev === "revealing" || prev === "holding" ? "fading" : prev
     );
     const doneTimer = window.setTimeout(() => {
-      window.sessionStorage.setItem(STORAGE_KEY, "1");
+      window.sessionStorage.setItem(PLAYED_MARKER, "1");
       setPhase("done");
     }, FADE_MS);
     timersRef.current = [doneTimer];
@@ -96,19 +69,8 @@ export default function PageLoadCurtain({
   }, []);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
     if (!sizeReady) return;
-    const debugBypass =
-      process.env.NODE_ENV !== "production" &&
-      new URLSearchParams(window.location.search).has("forceCurtain");
-    if (reduce && !debugBypass) {
-      setPhase("done");
-      return;
-    }
-    if (
-      !debugBypass &&
-      window.sessionStorage.getItem(STORAGE_KEY) === "1"
-    ) {
+    if (shouldSkipCurtain(Boolean(reduce), isDebugBypass())) {
       setPhase("done");
       return;
     }
@@ -122,11 +84,14 @@ export default function PageLoadCurtain({
       REVEAL_MS
     );
     const fadeTimer = window.setTimeout(
-      () => setPhase((p) => (p === "holding" || p === "revealing" ? "fading" : p)),
+      () =>
+        setPhase((p) =>
+          p === "holding" || p === "revealing" ? "fading" : p
+        ),
       REVEAL_MS + HOLD_MS
     );
     const doneTimer = window.setTimeout(() => {
-      window.sessionStorage.setItem(STORAGE_KEY, "1");
+      window.sessionStorage.setItem(PLAYED_MARKER, "1");
       setPhase("done");
     }, REVEAL_MS + HOLD_MS + FADE_MS);
 
@@ -163,7 +128,8 @@ export default function PageLoadCurtain({
 
   const visible = phase !== "done";
   const fading = phase === "fading";
-  const showMark = phase === "revealing" || phase === "holding" || phase === "fading";
+  const showMark =
+    phase === "revealing" || phase === "holding" || phase === "fading";
 
   if (visible && !mounted) {
     return (
@@ -210,9 +176,7 @@ export default function PageLoadCurtain({
                 transition={{
                   opacity: {
                     duration: fading ? FADE_MS / 1000 : REVEAL_MS / 1000,
-                    ease: fading
-                      ? [0.4, 0, 0.6, 1]
-                      : [0.22, 1, 0.36, 1],
+                    ease: fading ? [0.4, 0, 0.6, 1] : [0.22, 1, 0.36, 1],
                   },
                   scale: {
                     duration: fading ? FADE_MS / 1000 : REVEAL_MS / 1000,

--- a/app/components/page-load-curtain.tsx
+++ b/app/components/page-load-curtain.tsx
@@ -1,45 +1,64 @@
 "use client";
-import React, { useCallback, useEffect, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import Monogram from "./monogram";
 
 const STORAGE_KEY = "mono-curtain-played";
 
-// Phase timings — total ~4 seconds on first visit
-const DRAW_MS = 2600;   // ligature draws (O outline → A → crossbar → B spine → B bowls)
-const SETTLE_MS = 600;  // dwell at full size before transitioning
-const EXIT_MS = 900;    // morph to navbar position + backdrop fade
+// Phase timings — total ~4.1s on first visit.
+const REVEAL_MS_BASE = 1100; // mark fades in (opacity + scale)
+const HOLD_MS_BASE = 2000;   // mark sits at full presence
+const FADE_MS_BASE = 1000;   // backdrop + mark fade together (slow exhale)
 
-// Final landing height for the morph: matches navbar Monogram size={36}.
-const NAVBAR_SIZE = 36;
-// Maximum monogram height at centre-stage; capped to avoid overflow on
-// short viewports. Computed at mount time from viewport dimensions.
-const MAX_HERO_SIZE = 480;
+const MAX_HERO_SIZE = 540;
+const CHECKING_HERO_SIZE = 360;
 
-type Phase = "idle" | "showing" | "settled" | "exiting" | "done";
+// Dev-only `?slow=N` slowdown factor for visual QA. Constant-folded out
+// in production builds.
+function getSlowdown() {
+  if (process.env.NODE_ENV === "production") return 1;
+  if (typeof window === "undefined") return 1;
+  const v = parseFloat(new URLSearchParams(window.location.search).get("slow") || "1");
+  return Number.isFinite(v) && v > 0 ? v : 1;
+}
 
-function computeHeroSize() {
+const SLOW = getSlowdown();
+const REVEAL_MS = REVEAL_MS_BASE * SLOW;
+const HOLD_MS = HOLD_MS_BASE * SLOW;
+const FADE_MS = FADE_MS_BASE * SLOW;
+
+const useIsoLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+const CURTAIN_STYLE: React.CSSProperties = {
+  willChange: "opacity",
+  background:
+    "radial-gradient(ellipse at 50% 48%, rgba(247, 217, 149, 0.08), rgba(5, 5, 5, 0) 32rem), var(--color-bg)",
+};
+
+type Phase = "checking" | "revealing" | "holding" | "fading" | "done";
+
+function computeHeroSize(): number {
   if (typeof window === "undefined") return MAX_HERO_SIZE;
-  // Monogram width = size * 0.75; size === height. Cap on both dimensions.
-  const byHeight = window.innerHeight * 0.6;
-  const byWidth = (window.innerWidth * 0.6) / 0.75;
-  return Math.max(160, Math.min(byHeight, byWidth, MAX_HERO_SIZE));
+  const byHeight = window.innerHeight * 0.55;
+  const byWidth = (window.innerWidth * 0.45) / 0.75;
+  return Math.max(180, Math.min(byHeight, byWidth, MAX_HERO_SIZE));
 }
 
 /**
- * First-visit-only entry sequence. The OAB ligature draws large at
- * centre, settles for ~600ms at full opacity, then morphs (scale +
- * position) to navbar position while the backdrop fades — feels like
- * the mark "landing" in its permanent spot.
+ * First-visit-only entry sequence. The OAB ligature reveals quietly at
+ * centre — scaling up from a slight 0.94 with opacity fade — holds for
+ * a beat, then fades out together with the dark backdrop. No drawing,
+ * no morph. Restraint over decoration.
  *
- * Skip on Esc or click anywhere on the curtain. sessionStorage gate
- * suppresses the curtain on subsequent visits in the same session.
- * Skipped entirely under prefers-reduced-motion.
- *
- * No useEffect cleanup on the timer chain — in React 18 StrictMode
- * dev mode the cleanup would cancel timers between the synthetic
- * unmount/remount, leaving the curtain stuck. The setPhase calls and
- * sessionStorage write are idempotent.
+ * Skip on Esc or click. sessionStorage gate suppresses on subsequent
+ * visits in the same session. Skipped entirely under prefers-reduced-motion.
  */
 export default function PageLoadCurtain({
   children,
@@ -47,20 +66,30 @@ export default function PageLoadCurtain({
   children: React.ReactNode;
 }) {
   const reduce = useReducedMotion();
-  const [phase, setPhase] = useState<Phase>("idle");
-  const [heroSize, setHeroSize] = useState<number>(MAX_HERO_SIZE);
+  const [phase, setPhase] = useState<Phase>("checking");
+  const [heroSize, setHeroSize] = useState<number>(CHECKING_HERO_SIZE);
+  const [mounted, setMounted] = useState(false);
+  const [sizeReady, setSizeReady] = useState(false);
+  const startedRef = useRef(false);
+  const timersRef = useRef<number[]>([]);
 
-  const skipToExit = useCallback(() => {
+  const skipToFade = useCallback(() => {
+    timersRef.current.forEach((timer) => window.clearTimeout(timer));
     setPhase((prev) =>
-      prev === "showing" || prev === "settled" ? "exiting" : prev
+      prev === "revealing" || prev === "holding" ? "fading" : prev
     );
+    const doneTimer = window.setTimeout(() => {
+      window.sessionStorage.setItem(STORAGE_KEY, "1");
+      setPhase("done");
+    }, FADE_MS);
+    timersRef.current = [doneTimer];
   }, []);
 
-  // Compute hero monogram size based on viewport. Refresh on resize so
-  // mid-curtain rotation/zoom doesn't leave the mark off-screen.
-  useEffect(() => {
+  useIsoLayoutEffect(() => {
     if (typeof window === "undefined") return;
     setHeroSize(computeHeroSize());
+    setMounted(true);
+    setSizeReady(true);
     const onResize = () => setHeroSize(computeHeroSize());
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
@@ -68,58 +97,87 @@ export default function PageLoadCurtain({
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (reduce) {
+    if (!sizeReady) return;
+    const debugBypass =
+      process.env.NODE_ENV !== "production" &&
+      new URLSearchParams(window.location.search).has("forceCurtain");
+    if (reduce && !debugBypass) {
       setPhase("done");
       return;
     }
-    if (window.sessionStorage.getItem(STORAGE_KEY) === "1") {
+    if (
+      !debugBypass &&
+      window.sessionStorage.getItem(STORAGE_KEY) === "1"
+    ) {
       setPhase("done");
       return;
     }
+    if (startedRef.current) return;
 
-    setPhase("showing");
+    startedRef.current = true;
+    setPhase("revealing");
 
-    window.setTimeout(
-      () => setPhase((p) => (p === "showing" ? "settled" : p)),
-      DRAW_MS
+    const holdTimer = window.setTimeout(
+      () => setPhase((p) => (p === "revealing" ? "holding" : p)),
+      REVEAL_MS
     );
-    window.setTimeout(
-      () => setPhase((p) => (p === "settled" || p === "showing" ? "exiting" : p)),
-      DRAW_MS + SETTLE_MS
+    const fadeTimer = window.setTimeout(
+      () => setPhase((p) => (p === "holding" || p === "revealing" ? "fading" : p)),
+      REVEAL_MS + HOLD_MS
     );
-    window.setTimeout(() => {
+    const doneTimer = window.setTimeout(() => {
       window.sessionStorage.setItem(STORAGE_KEY, "1");
       setPhase("done");
-    }, DRAW_MS + SETTLE_MS + EXIT_MS);
-  }, [reduce]);
+    }, REVEAL_MS + HOLD_MS + FADE_MS);
+
+    timersRef.current = [holdTimer, fadeTimer, doneTimer];
+
+    return () => {
+      timersRef.current.forEach((timer) => window.clearTimeout(timer));
+      timersRef.current = [];
+      startedRef.current = false;
+    };
+  }, [reduce, sizeReady]);
 
   // Skip on Escape — only meaningful while curtain is interactive
   useEffect(() => {
-    if (phase !== "showing" && phase !== "settled") return;
+    if (phase !== "revealing" && phase !== "holding") return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") skipToExit();
+      if (e.key === "Escape") skipToFade();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [phase, skipToExit]);
+  }, [phase, skipToFade]);
 
-  const visible =
-    phase === "showing" || phase === "settled" || phase === "exiting";
+  // DEV-ONLY: expose phase on window for visual diagnostics. Stripped
+  // from production bundle by NODE_ENV constant fold.
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+    if (typeof window === "undefined") return;
+    (window as unknown as Record<string, unknown>).__curtain = {
+      phase,
+      heroSize,
+      t: Math.round(performance.now()),
+    };
+  }, [phase, heroSize]);
 
-  // Final landing scale: navbar mark / hero mark
-  const exitScale = NAVBAR_SIZE / heroSize;
+  const visible = phase !== "done";
+  const fading = phase === "fading";
+  const showMark = phase === "revealing" || phase === "holding" || phase === "fading";
 
-  // Centred state: place the monogram's centre at viewport centre.
-  // Half-dimensions in px (monogram width = heroSize * 0.75).
-  const heroHalfW = (heroSize * 0.75) / 2;
-  const heroHalfH = heroSize / 2;
-
-  // Exit state: navbar-mark position. The navbar's container has
-  // px-4 (16px) on mobile, sm:px-6 (24px), lg:px-8 (32px). Use 32px
-  // as the most common breakpoint; on smaller viewports the visual
-  // mismatch is a few pixels — invisible during the morph.
-  const navbarLeft = 32;
-  const navbarTop = 14;
+  if (visible && !mounted) {
+    return (
+      <>
+        {children}
+        <div
+          className="fixed inset-0 z-[100] overflow-hidden"
+          style={CURTAIN_STYLE}
+          aria-hidden="true"
+          role="presentation"
+        />
+      </>
+    );
+  }
 
   return (
     <>
@@ -128,51 +186,43 @@ export default function PageLoadCurtain({
         {visible ? (
           <motion.div
             key="curtain"
-            className="fixed inset-0 z-[100] bg-base cursor-pointer"
+            className="fixed inset-0 z-[100] overflow-hidden flex items-center justify-center"
+            style={CURTAIN_STYLE}
             aria-hidden="true"
             role="presentation"
-            onClick={skipToExit}
+            onClick={skipToFade}
             initial={{ opacity: 1 }}
-            animate={{ opacity: phase === "exiting" ? 0 : 1 }}
+            animate={{ opacity: fading ? 0 : 1 }}
             transition={{
-              duration: EXIT_MS / 1000,
+              duration: FADE_MS / 1000,
               ease: [0.25, 0.46, 0.45, 0.94],
             }}
           >
-            <motion.div
-              className="fixed text-accent"
-              style={{ transformOrigin: "top left" }}
-              initial={{
-                top: "50%",
-                left: "50%",
-                x: -heroHalfW,
-                y: -heroHalfH,
-                scale: 1,
-              }}
-              animate={
-                phase === "exiting"
-                  ? {
-                      top: navbarTop,
-                      left: navbarLeft,
-                      x: 0,
-                      y: 0,
-                      scale: exitScale,
-                    }
-                  : {
-                      top: "50%",
-                      left: "50%",
-                      x: -heroHalfW,
-                      y: -heroHalfH,
-                      scale: 1,
-                    }
-              }
-              transition={{
-                duration: EXIT_MS / 1000,
-                ease: [0.25, 0.46, 0.45, 0.94],
-              }}
-            >
-              <Monogram size={heroSize} animate={phase === "showing"} />
-            </motion.div>
+            {showMark && (
+              <motion.div
+                key="mark"
+                className="text-accent"
+                initial={{ opacity: 0, scale: 0.96 }}
+                animate={{
+                  opacity: fading ? 0 : 1,
+                  scale: fading ? 1.02 : 1,
+                }}
+                transition={{
+                  opacity: {
+                    duration: fading ? FADE_MS / 1000 : REVEAL_MS / 1000,
+                    ease: fading
+                      ? [0.4, 0, 0.6, 1]
+                      : [0.22, 1, 0.36, 1],
+                  },
+                  scale: {
+                    duration: fading ? FADE_MS / 1000 : REVEAL_MS / 1000,
+                    ease: [0.22, 1, 0.36, 1],
+                  },
+                }}
+              >
+                <Monogram size={heroSize} aria-hidden />
+              </motion.div>
+            )}
           </motion.div>
         ) : null}
       </AnimatePresence>

--- a/app/components/page-load-curtain.tsx
+++ b/app/components/page-load-curtain.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import Monogram from "./monogram";
 
 const STORAGE_KEY = "mono-curtain-played";
-const HOLD_MS = 2400; // monogram drawing (~2s) + brief hold
+const HOLD_MS = 2400;
 const FADE_MS = 600;
 
 type Phase = "idle" | "showing" | "done";
@@ -14,8 +14,8 @@ type Phase = "idle" | "showing" | "done";
  * full-screen drawing in over ~2 seconds, then fades out. Subsequent
  * navigations skip via sessionStorage. Respects prefers-reduced-motion.
  *
- * Children are always rendered (SSR-safe); the curtain simply covers
- * them with z-100 for the first ~3 seconds.
+ * Children render always (SSR-safe); the curtain covers them with
+ * z-100 only on the very first visit per session.
  */
 export default function PageLoadCurtain({
   children,
@@ -23,24 +23,34 @@ export default function PageLoadCurtain({
   children: React.ReactNode;
 }) {
   const reduce = useReducedMotion();
-  // Always start "idle" on the server. The curtain decision is taken
-  // on the client inside the effect below — avoids hydration mismatch.
   const [phase, setPhase] = useState<Phase>("idle");
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+
     if (reduce) {
       setPhase("done");
       return;
     }
+
     if (window.sessionStorage.getItem(STORAGE_KEY) === "1") {
       setPhase("done");
       return;
     }
+
     setPhase("showing");
-    window.sessionStorage.setItem(STORAGE_KEY, "1");
-    const timer = window.setTimeout(() => setPhase("done"), HOLD_MS);
-    return () => window.clearTimeout(timer);
+
+    const timer = window.setTimeout(() => {
+      window.sessionStorage.setItem(STORAGE_KEY, "1");
+      setPhase("done");
+    }, HOLD_MS);
+
+    // Note: no cleanup. In React 18 StrictMode dev, the cleanup would
+    // fire between the synthetic unmount/remount and cancel the only
+    // scheduled timer, leaving the curtain mounted forever. The
+    // sessionStorage gate above handles legitimate remounts (route
+    // changes); StrictMode's double-invoke is harmless because the
+    // setTimeout body is idempotent.
   }, [reduce]);
 
   return (
@@ -51,6 +61,7 @@ export default function PageLoadCurtain({
           <motion.div
             key="curtain"
             initial={{ opacity: 1 }}
+            animate={{ opacity: 1 }}
             exit={{
               opacity: 0,
               transition: { duration: FADE_MS / 1000, ease: "easeOut" },

--- a/app/components/page-load-curtain.tsx
+++ b/app/components/page-load-curtain.tsx
@@ -1,21 +1,45 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import Monogram from "./monogram";
 
 const STORAGE_KEY = "mono-curtain-played";
-const HOLD_MS = 3200; // ligature draws ~2.6s + brief hold
-const FADE_MS = 600;
 
-type Phase = "idle" | "showing" | "done";
+// Phase timings — total ~4 seconds on first visit
+const DRAW_MS = 2600;   // ligature draws (O outline → A → crossbar → B spine → B bowls)
+const SETTLE_MS = 600;  // dwell at full size before transitioning
+const EXIT_MS = 900;    // morph to navbar position + backdrop fade
+
+// Final landing height for the morph: matches navbar Monogram size={36}.
+const NAVBAR_SIZE = 36;
+// Maximum monogram height at centre-stage; capped to avoid overflow on
+// short viewports. Computed at mount time from viewport dimensions.
+const MAX_HERO_SIZE = 480;
+
+type Phase = "idle" | "showing" | "settled" | "exiting" | "done";
+
+function computeHeroSize() {
+  if (typeof window === "undefined") return MAX_HERO_SIZE;
+  // Monogram width = size * 0.75; size === height. Cap on both dimensions.
+  const byHeight = window.innerHeight * 0.6;
+  const byWidth = (window.innerWidth * 0.6) / 0.75;
+  return Math.max(160, Math.min(byHeight, byWidth, MAX_HERO_SIZE));
+}
 
 /**
- * First-visit-only page-load curtain. Renders the OAB monogram
- * full-screen drawing in over ~2 seconds, then fades out. Subsequent
- * navigations skip via sessionStorage. Respects prefers-reduced-motion.
+ * First-visit-only entry sequence. The OAB ligature draws large at
+ * centre, settles for ~600ms at full opacity, then morphs (scale +
+ * position) to navbar position while the backdrop fades — feels like
+ * the mark "landing" in its permanent spot.
  *
- * Children render always (SSR-safe); the curtain covers them with
- * z-100 only on the very first visit per session.
+ * Skip on Esc or click anywhere on the curtain. sessionStorage gate
+ * suppresses the curtain on subsequent visits in the same session.
+ * Skipped entirely under prefers-reduced-motion.
+ *
+ * No useEffect cleanup on the timer chain — in React 18 StrictMode
+ * dev mode the cleanup would cancel timers between the synthetic
+ * unmount/remount, leaving the curtain stuck. The setPhase calls and
+ * sessionStorage write are idempotent.
  */
 export default function PageLoadCurtain({
   children,
@@ -24,15 +48,30 @@ export default function PageLoadCurtain({
 }) {
   const reduce = useReducedMotion();
   const [phase, setPhase] = useState<Phase>("idle");
+  const [heroSize, setHeroSize] = useState<number>(MAX_HERO_SIZE);
+
+  const skipToExit = useCallback(() => {
+    setPhase((prev) =>
+      prev === "showing" || prev === "settled" ? "exiting" : prev
+    );
+  }, []);
+
+  // Compute hero monogram size based on viewport. Refresh on resize so
+  // mid-curtain rotation/zoom doesn't leave the mark off-screen.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setHeroSize(computeHeroSize());
+    const onResize = () => setHeroSize(computeHeroSize());
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-
     if (reduce) {
       setPhase("done");
       return;
     }
-
     if (window.sessionStorage.getItem(STORAGE_KEY) === "1") {
       setPhase("done");
       return;
@@ -40,36 +79,100 @@ export default function PageLoadCurtain({
 
     setPhase("showing");
 
-    const timer = window.setTimeout(() => {
+    window.setTimeout(
+      () => setPhase((p) => (p === "showing" ? "settled" : p)),
+      DRAW_MS
+    );
+    window.setTimeout(
+      () => setPhase((p) => (p === "settled" || p === "showing" ? "exiting" : p)),
+      DRAW_MS + SETTLE_MS
+    );
+    window.setTimeout(() => {
       window.sessionStorage.setItem(STORAGE_KEY, "1");
       setPhase("done");
-    }, HOLD_MS);
-
-    // Note: no cleanup. In React 18 StrictMode dev, the cleanup would
-    // fire between the synthetic unmount/remount and cancel the only
-    // scheduled timer, leaving the curtain mounted forever. The
-    // sessionStorage gate above handles legitimate remounts (route
-    // changes); StrictMode's double-invoke is harmless because the
-    // setTimeout body is idempotent.
+    }, DRAW_MS + SETTLE_MS + EXIT_MS);
   }, [reduce]);
+
+  // Skip on Escape — only meaningful while curtain is interactive
+  useEffect(() => {
+    if (phase !== "showing" && phase !== "settled") return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") skipToExit();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [phase, skipToExit]);
+
+  const visible =
+    phase === "showing" || phase === "settled" || phase === "exiting";
+
+  // Final landing scale: navbar mark / hero mark
+  const exitScale = NAVBAR_SIZE / heroSize;
+
+  // Centred state: place the monogram's centre at viewport centre.
+  // Half-dimensions in px (monogram width = heroSize * 0.75).
+  const heroHalfW = (heroSize * 0.75) / 2;
+  const heroHalfH = heroSize / 2;
+
+  // Exit state: navbar-mark position. The navbar's container has
+  // px-4 (16px) on mobile, sm:px-6 (24px), lg:px-8 (32px). Use 32px
+  // as the most common breakpoint; on smaller viewports the visual
+  // mismatch is a few pixels — invisible during the morph.
+  const navbarLeft = 32;
+  const navbarTop = 14;
 
   return (
     <>
       {children}
       <AnimatePresence>
-        {phase === "showing" ? (
+        {visible ? (
           <motion.div
             key="curtain"
-            initial={{ opacity: 1 }}
-            animate={{ opacity: 1 }}
-            exit={{
-              opacity: 0,
-              transition: { duration: FADE_MS / 1000, ease: "easeOut" },
-            }}
-            className="fixed inset-0 z-[100] flex items-center justify-center bg-base"
+            className="fixed inset-0 z-[100] bg-base cursor-pointer"
             aria-hidden="true"
+            role="presentation"
+            onClick={skipToExit}
+            initial={{ opacity: 1 }}
+            animate={{ opacity: phase === "exiting" ? 0 : 1 }}
+            transition={{
+              duration: EXIT_MS / 1000,
+              ease: [0.25, 0.46, 0.45, 0.94],
+            }}
           >
-            <Monogram size={280} animate />
+            <motion.div
+              className="fixed text-accent"
+              style={{ transformOrigin: "top left" }}
+              initial={{
+                top: "50%",
+                left: "50%",
+                x: -heroHalfW,
+                y: -heroHalfH,
+                scale: 1,
+              }}
+              animate={
+                phase === "exiting"
+                  ? {
+                      top: navbarTop,
+                      left: navbarLeft,
+                      x: 0,
+                      y: 0,
+                      scale: exitScale,
+                    }
+                  : {
+                      top: "50%",
+                      left: "50%",
+                      x: -heroHalfW,
+                      y: -heroHalfH,
+                      scale: 1,
+                    }
+              }
+              transition={{
+                duration: EXIT_MS / 1000,
+                ease: [0.25, 0.46, 0.45, 0.94],
+              }}
+            >
+              <Monogram size={heroSize} animate={phase === "showing"} />
+            </motion.div>
           </motion.div>
         ) : null}
       </AnimatePresence>

--- a/app/components/products-section.tsx
+++ b/app/components/products-section.tsx
@@ -30,7 +30,7 @@ export default function ProductsSection() {
             className="text-accent font-medium uppercase tracking-[0.05em] mb-6"
             style={{ fontSize: "var(--text-xs)" }}
           >
-            Projects
+            <span className="text-muted">02 /</span> Projects
           </p>
 
           <h2

--- a/app/components/pull-quote.tsx
+++ b/app/components/pull-quote.tsx
@@ -1,0 +1,34 @@
+"use client";
+import React from "react";
+import { motion } from "framer-motion";
+
+interface PullQuoteProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Editorial pull-quote — full-bleed row, Fraunces display face, hairline
+ * rules above and below, single fade-up reveal on scroll. Lifts a sentence
+ * from body copy and gives it the typographic weight it earns.
+ */
+export default function PullQuote({ children }: PullQuoteProps) {
+  return (
+    <section
+      aria-hidden="false"
+      className="border-y border-edge"
+    >
+      <div className="max-w-container mx-auto px-4 sm:px-6 lg:px-8 py-32 lg:py-40">
+        <motion.blockquote
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+          viewport={{ once: true, margin: "-50px" }}
+          className="font-display font-extralight tracking-[-0.02em] text-primary leading-[1.15] max-w-4xl"
+          style={{ fontSize: "var(--text-4xl)" }}
+        >
+          {children}
+        </motion.blockquote>
+      </div>
+    </section>
+  );
+}

--- a/app/data/experiences.ts
+++ b/app/data/experiences.ts
@@ -15,7 +15,7 @@ const experiences: Experience[] = [
       "Three production AI platforms, built solo. Full-stack across Python, TypeScript, React, FastAPI, Next.js, and Electron, with PostgreSQL, Neo4j, Redis, and FalkorDB beneath. ~3,000 automated tests across backend, integration, prompt evaluation, and end-to-end workflows.",
     outcomes: [
       "ruleIQ — agentic compliance platform on a GraphRAG knowledge layer; supports ISO 27001, GDPR, Cyber Essentials, SOC 2, PCI DSS",
-      "Helios — autonomous B2B sales engine; deployed at RTGS.global with a 25% lift in lead conversion",
+      "Helios — autonomous B2B sales engine; live in production at RTGS.global",
       "thredOS — multi-agent workflow runtime; in final testing ahead of commercial launch",
     ],
   },
@@ -26,7 +26,7 @@ const experiences: Experience[] = [
     description:
       "Led commercial partnerships and AI strategy for a cross-border payments infrastructure business operating across Asia and EMEA.",
     outcomes: [
-      "Built and deployed Helios as the company's primary AI-driven commercial platform; +25% lead conversion, replacing manual prospecting",
+      "Built and deployed Helios as the company's primary AI-driven commercial platform, running outbound sales end-to-end",
       "Led AI strategy for commercial execution — translated automation opportunities into shipped production systems",
       "Worked across Product, Engineering, Compliance, and Commercial to convert market feedback into structured product improvements",
     ],

--- a/app/data/products.ts
+++ b/app/data/products.ts
@@ -34,7 +34,7 @@ const products: Product[] = [
   },
   {
     name: "Helios",
-    tagline: "Autonomous B2B sales engine — deployed at RTGS.global, +25% conversion",
+    tagline: "Autonomous B2B sales engine, live in production at RTGS.global",
     description:
       "End-to-end autonomous prospecting and outreach automation, with safety hard-baked into the architecture: circuit breakers, spend caps, and mandatory cancel windows to prevent runaway automation. A desktop app, an API server, and a Python orchestrator working in concert, integrated with Explorium, Apollo, HubSpot, and Postmark. Replaced a manual prospecting workflow in a live commercial environment.",
     stack: [
@@ -48,7 +48,7 @@ const products: Product[] = [
       "Redis",
     ],
     highlights: [
-      "Deployed in production at RTGS.global; lead conversion +25%, manual prospecting retired",
+      "Live in production at RTGS.global, running the company's outbound sales motion end-to-end",
       "Multi-agent framework with autonomous execution mode and persistent context (Graphiti)",
       "26-view desktop app: Clerk auth, Zustand state management",
       "Integrations: Explorium, Apollo, HubSpot, Postmark",

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -4,6 +4,18 @@ export const runtime = "edge";
 export const size = { width: 32, height: 32 };
 export const contentType = "image/png";
 
+// Path data shared with app/components/monogram.tsx — Codex-generated OAB
+// ligature, geometry-only (no <text>) so @vercel/og can render it.
+const PATHS = {
+  oOutline:
+    "M75 15C107 15 126 52 126 100C126 148 107 185 75 185C43 185 24 148 24 100C24 52 43 15 75 15Z",
+  aStroke:
+    "M47 104C49 103 51 103 53 103L75 39L97 103C99 103 101 103 103 104",
+  abCrossbar: "M55 94C66 92 84 92 96 94",
+  bSpine: "M75 94L75 162",
+  bBowls: "M75 96C105 96 111 122 77 127C113 130 111 160 75 160",
+};
+
 export default function Icon() {
   return new ImageResponse(
     (
@@ -19,45 +31,19 @@ export default function Icon() {
         }}
       >
         <svg width="28" height="28" viewBox="0 0 150 200" fill="none">
-          <ellipse
-            cx="75"
-            cy="100"
-            rx="64"
-            ry="90"
+          <g
             stroke="#C4A265"
             strokeWidth="6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             fill="none"
-          />
-          <text
-            x="75"
-            y="88"
-            textAnchor="middle"
-            fontFamily="Georgia, serif"
-            fontSize="78"
-            fontWeight="400"
-            fill="#C4A265"
           >
-            A
-          </text>
-          <line
-            x1="38"
-            y1="102"
-            x2="112"
-            y2="102"
-            stroke="#C4A265"
-            strokeWidth="4"
-          />
-          <text
-            x="75"
-            y="170"
-            textAnchor="middle"
-            fontFamily="Georgia, serif"
-            fontSize="78"
-            fontWeight="400"
-            fill="#C4A265"
-          >
-            B
-          </text>
+            <path d={PATHS.oOutline} />
+            <path d={PATHS.aStroke} />
+            <path d={PATHS.abCrossbar} />
+            <path d={PATHS.bSpine} />
+            <path d={PATHS.bBowls} />
+          </g>
         </svg>
       </div>
     ),

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Fraunces } from "next/font/google";
 import "./globals.css";
 import MotionProvider from "./components/motion-provider";
 import StructuredData from "./components/structured-data";
@@ -10,6 +10,15 @@ const inter = Inter({
   preload: true,
   fallback: ["system-ui", "sans-serif"],
   variable: "--font-inter",
+});
+
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  display: "swap",
+  preload: true,
+  axes: ["SOFT", "WONK", "opsz"],
+  fallback: ["Georgia", "serif"],
+  variable: "--font-fraunces",
 });
 
 export const metadata: Metadata = {
@@ -77,7 +86,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en" className={`${inter.variable} ${fraunces.variable}`}>
       <head>
         <link rel="preconnect" href="https://api.iconify.design" />
         <link rel="dns-prefetch" href="https://api.iconify.design" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,30 +9,33 @@ import ExpertiseSection from "@/app/components/expertise-section";
 import NewsletterSection from "@/app/components/newsletter-section";
 import ContactSection from "@/app/components/contact-section";
 import Footer from "@/app/components/footer";
+import PageLoadCurtain from "@/app/components/page-load-curtain";
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-base text-primary overflow-x-hidden">
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-accent focus:text-primary"
-      >
-        Skip to content
-      </a>
+    <PageLoadCurtain>
+      <div className="min-h-screen bg-base text-primary overflow-x-hidden">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-accent focus:text-primary"
+        >
+          Skip to content
+        </a>
 
-      <Navbar />
+        <Navbar />
 
-      <main id="main-content">
-        <HeroSection />
-        <AboutSection />
-        <ProductsSection />
-        <ExperienceSection />
-        <ExpertiseSection />
-        <NewsletterSection />
-        <ContactSection />
-      </main>
+        <main id="main-content">
+          <HeroSection />
+          <AboutSection />
+          <ProductsSection />
+          <ExperienceSection />
+          <ExpertiseSection />
+          <NewsletterSection />
+          <ContactSection />
+        </main>
 
-      <Footer />
-    </div>
+        <Footer />
+      </div>
+    </PageLoadCurtain>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import NewsletterSection from "@/app/components/newsletter-section";
 import ContactSection from "@/app/components/contact-section";
 import Footer from "@/app/components/footer";
 import PageLoadCurtain from "@/app/components/page-load-curtain";
+import PullQuote from "@/app/components/pull-quote";
 
 export default function HomePage() {
   return (
@@ -27,6 +28,10 @@ export default function HomePage() {
         <main id="main-content">
           <HeroSection />
           <AboutSection />
+          <PullQuote>
+            This isn&rsquo;t a pivot. It&rsquo;s both halves of a job that
+            should have been one job all along.
+          </PullQuote>
           <ProductsSection />
           <ExperienceSection />
           <ExpertiseSection />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import React from "react";
 import Navbar from "@/app/components/navbar";
 import HeroSection from "@/app/components/hero-section";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,7 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
+        display: ['var(--font-fraunces)', 'Georgia', 'serif'],
       },
       colors: {
         base: '#0A0A0A',


### PR DESCRIPTION
## Summary
Builds on #1 (`feat/copy-and-a11y-pass`). Three editorial moves to lift the page from refined-minimalism to editorial-minimalism — the Monocle anchor named in `DESIGN_DIRECTION_DECLARATION.md`.

- Typography: pair Inter (body) with Fraunces (variable serif display, axes SOFT/WONK/opsz). Applied to Hero H1 and About H2 only. Declaration ratified to v1.1, status APPROVED.
- Motion: restore the signature OAB monogram page-load curtain on first visit (sessionStorage-gated, `useReducedMotion` respected, SSR-safe).
- Layout: asymmetric hero (name top-left stacked, story bottom-right), numbered section eyebrows (01/About → 06/Contact), editorial pull-quote between About and Products lifting the "not a pivot / both halves of a job" line from body copy.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next lint --max-warnings 0` clean
- [x] Live page returns 200 with all anchor strings in SSR HTML
- [x] Fraunces loaded (CSS contains `--font-fraunces`)
- [ ] Visual review with Reduce Motion OFF — verify monogram curtain plays once and tunnel renders
- [ ] Visual review with Reduce Motion ON — verify both fall back gracefully (tunnel → flat bg, curtain → skipped)
- [ ] Mobile review at 375/768px — asymmetric hero collapses to single column

## Notes
- Pre-existing `/icon` 500 (SVG `<text>` not supported by `@vercel/og`) noted but not addressed in this PR — handle separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)