### PR TITLE
Fix Chrome animations and Cloudflare CSP

### DIFF
--- a/app/components/motion-provider.tsx
+++ b/app/components/motion-provider.tsx
@@ -2,22 +2,31 @@
 
 import React from "react";
 import { MotionConfig } from "framer-motion";
+import {
+  getMotionPreference,
+  type MotionPreference,
+} from "@/lib/motion-preference";
 
 export default function MotionProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const [forceFullMotion, setForceFullMotion] = React.useState(false);
+  const [preference, setPreference] = React.useState<MotionPreference>("full");
 
   React.useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    setForceFullMotion(params.get("motion") === "full");
+    const syncPreference = () => setPreference(getMotionPreference());
+    syncPreference();
+    window.addEventListener("popstate", syncPreference);
+    return () => window.removeEventListener("popstate", syncPreference);
   }, []);
 
-  return (
-    <MotionConfig reducedMotion={forceFullMotion ? "never" : "user"}>
-      {children}
-    </MotionConfig>
-  );
+  const reducedMotion =
+    preference === "reduce"
+      ? "always"
+      : preference === "system"
+        ? "user"
+        : "never";
+
+  return <MotionConfig reducedMotion={reducedMotion}>{children}</MotionConfig>;
 }

--- a/app/components/page-load-curtain.config.ts
+++ b/app/components/page-load-curtain.config.ts
@@ -1,4 +1,5 @@
 import type React from "react";
+import { getMotionPreference, shouldReduceMotion } from "@/lib/motion-preference";
 
 const REVEAL_MS_BASE = 550;
 const HOLD_MS_BASE = 450;
@@ -38,8 +39,7 @@ export function computeHeroSize(): number {
 }
 
 export function isFullMotionOverride(): boolean {
-  if (typeof window === "undefined") return false;
-  return new URLSearchParams(window.location.search).get("motion") === "full";
+  return getMotionPreference() === "full";
 }
 
 export function isDebugBypass(): boolean {
@@ -50,9 +50,8 @@ export function isDebugBypass(): boolean {
 
 export function shouldSkipCurtain(
   reduceMotion: boolean,
-  debugBypass: boolean,
-  fullMotionOverride = false
+  debugBypass: boolean
 ): boolean {
-  if (debugBypass || fullMotionOverride) return false;
-  return reduceMotion;
+  if (debugBypass) return false;
+  return shouldReduceMotion(getMotionPreference(), reduceMotion);
 }

--- a/app/components/page-load-curtain.tsx
+++ b/app/components/page-load-curtain.tsx
@@ -18,7 +18,6 @@ import {
   REVEAL_MS,
   computeHeroSize,
   isDebugBypass,
-  isFullMotionOverride,
   shouldSkipCurtain,
 } from "./page-load-curtain.config";
 
@@ -71,11 +70,7 @@ export default function PageLoadCurtain({
   useEffect(() => {
     if (!mounted) return;
     if (
-      shouldSkipCurtain(
-        Boolean(reduceMotion),
-        isDebugBypass(),
-        isFullMotionOverride()
-      )
+      shouldSkipCurtain(Boolean(reduceMotion), isDebugBypass())
     ) {
       setPhase("done");
       return;

--- a/components/ui/tunnel-background.tsx
+++ b/components/ui/tunnel-background.tsx
@@ -2,6 +2,7 @@
 
 import * as THREE from "three";
 import { useRef, useEffect, useState, useCallback, type CSSProperties } from "react";
+import { getMotionPreference, shouldReduceMotion } from "@/lib/motion-preference";
 
 /* ----------------------------- utilities ----------------------------- */
 
@@ -156,35 +157,25 @@ function disposeThree(ctx: ThreeContext) {
 
 /* ----------------------------- prefers-reduced-motion ----------------------------- */
 
-function hasFullMotionOverride() {
-  if (typeof window === "undefined") return false;
-  return new URLSearchParams(window.location.search).get("motion") === "full";
-}
-
 function usePrefersReducedMotion() {
-  const [reduce, setReduce] = useState(() =>
-    typeof window !== "undefined" && !hasFullMotionOverride()
-      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
-      : false
-  );
+  const [reduce, setReduce] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (hasFullMotionOverride()) {
-      setReduce(false);
+
+    const preference = getMotionPreference();
+    if (preference !== "system") {
+      setReduce(shouldReduceMotion(preference, false));
       return;
     }
+
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const onChange = (e: MediaQueryListEvent | MediaQueryList) =>
-      setReduce("matches" in e ? e.matches : (e as any).matches);
-    setReduce(mq.matches);
-    try {
-      mq.addEventListener("change", onChange as any);
-      return () => mq.removeEventListener("change", onChange as any);
-    } catch {
-      mq.addListener(onChange as any);
-      return () => mq.removeListener(onChange as any);
-    }
+    const onChange = (event: MediaQueryListEvent) =>
+      setReduce(shouldReduceMotion("system", event.matches));
+
+    setReduce(shouldReduceMotion("system", mq.matches));
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
   }, []);
 
   return reduce;

--- a/lib/motion-preference.ts
+++ b/lib/motion-preference.ts
@@ -1,0 +1,20 @@
+export type MotionPreference = "full" | "reduce" | "system";
+
+export function getMotionPreference(search?: string): MotionPreference {
+  const query =
+    search ??
+    (typeof window !== "undefined" ? window.location.search : "");
+  const value = new URLSearchParams(query).get("motion");
+
+  if (value === "reduce" || value === "system") return value;
+  return "full";
+}
+
+export function shouldReduceMotion(
+  preference: MotionPreference,
+  systemPrefersReduced: boolean
+): boolean {
+  if (preference === "full") return false;
+  if (preference === "reduce") return true;
+  return systemPrefersReduced;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,8 @@ export function middleware(request: NextRequest) {
 
   const csp = [
     "default-src 'self'",
-    `script-src 'self' 'unsafe-eval' 'unsafe-inline'`,
+    `script-src 'self' 'unsafe-eval' 'unsafe-inline' https://static.cloudflareinsights.com`,
+    `script-src-elem 'self' 'unsafe-inline' https://static.cloudflareinsights.com`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
     "font-src 'self' https://fonts.gstatic.com data:",


### PR DESCRIPTION
## Fixes

- makes full motion the site default across Chrome, Firefox and other browsers
- keeps explicit `?motion=reduce` and `?motion=system` controls
- applies the same motion policy to Framer Motion, the intro curtain and the WebGL tunnel
- allows the Cloudflare Web Analytics beacon under the existing CSP

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized motion preferences for full, reduced, or system-controlled animation settings.
  * Motion settings now stay synchronized when browser navigation changes the preference.
  * Page animations and backgrounds consistently follow the selected motion preference.

* **Bug Fixes**
  * Improved handling of reduced-motion settings across animated page elements.
  * Updated security policy support for required analytics scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->